### PR TITLE
爆弾が壁に潰された時に、爆弾の所有者の設置爆弾数が減少していなかったのを修正。

### DIFF
--- a/BombmanServer.java
+++ b/BombmanServer.java
@@ -779,7 +779,14 @@ public class BombmanServer {
                     walls.add(p);
                     blocks.removeIf(b -> b.pos.equals(p));
                     items.removeIf(item -> item.pos.equals(p));
-                    bombs.removeIf(b -> b.pos.equals(p));
+                    bombs.removeIf(b -> {
+                            if (b.pos.equals(p)) {
+                                b.owner.setBombCount--;
+                                return true;
+                            } else {
+                                return false;
+                            }
+                        });
                 }
             }
 


### PR DESCRIPTION
サドンデスになると爆弾の実質的な設置可能数が減ったり、爆弾が全く設置できなくなったりすることがありました。
